### PR TITLE
Fix `max_seq_length` bug in language-modeling example

### DIFF
--- a/examples/transformers/language-modeling/requirements.txt
+++ b/examples/transformers/language-modeling/requirements.txt
@@ -1,3 +1,3 @@
 transformers==4.6.1
-datasets
+datasets==1.8.0
 nltk


### PR DESCRIPTION
Addresses issue #7 

Added forced version of datasets to avoid unmatching versions of `transformers` and `datasets`.