### PR TITLE
Fix distillation of different HF/transformers models

### DIFF
--- a/examples/transformers/language-modeling/run_mlm.py
+++ b/examples/transformers/language-modeling/run_mlm.py
@@ -511,6 +511,9 @@ def main():
         train_result = trainer.train(resume_from_checkpoint=checkpoint)
         if distill_args.distill:
             hf_remove_teacher_from_student(trainer.model)
+            # There might have been a change in the forward signature of the model
+            # This hack will reset the signature saved in the trainer
+            trainer._signature_columns = None
         trainer.save_model()  # Saves the tokenizer too for easy upload
         metrics = train_result.metrics
 

--- a/examples/transformers/question-answering/run_qa.py
+++ b/examples/transformers/question-answering/run_qa.py
@@ -691,6 +691,9 @@ def main():
         train_result = trainer.train(resume_from_checkpoint=checkpoint)
         if distill_args.distill:
             hf_remove_teacher_from_student(trainer.model)
+            # There might have been a change in the forward signature of the model
+            # This hack will reset the signature saved in the trainer
+            trainer._signature_columns = None
         trainer.save_model()  # Saves the tokenizer too for easy upload
 
         metrics = train_result.metrics

--- a/examples/transformers/text-classification/run_glue.py
+++ b/examples/transformers/text-classification/run_glue.py
@@ -590,6 +590,9 @@ def main():
 
         if distill_args.distill:
             hf_remove_teacher_from_student(trainer.model)
+            # There might have been a change in the forward signature of the model
+            # This hack will reset the signature saved in the trainer
+            trainer._signature_columns = None
         trainer.save_model()  # Saves the tokenizer too for easy upload
 
         trainer.log_metrics("train", metrics)


### PR DESCRIPTION
Until now, if the teacher had a different signature than the student, `transformers.trainer` would delete the input that is not matching to the student's signature leading to the teacher not getting all the input it needs.

For example, training a DistilBERT student with a BERT-Base teacher will not work properly since BERT-Base requires `token_type_ids` which DistilBERT doesn't require. 
The trainer deletes the `token_type_ids` from the input and BERT teacher would get an all zeros token type ids leading to wrong predictions.

This PR fixes this issue.